### PR TITLE
feat: allow custom MyDumper tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/stasadev/ddev-mydumper/actions/workflows/tests.yml/badge.svg)](https://github.com/stasadev/ddev-mydumper/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/stasadev/ddev-mydumper/actions/workflows/tests.yml/badge.svg)](https://github.com/stasadev/ddev-mydumper/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)
 
 # DDEV MyDumper Add-on
 
@@ -27,6 +27,15 @@ ddev get stasadev/ddev-mydumper
 Then restart the project
 
 ```sh
+ddev restart
+```
+
+
+With DDEV v1.23.5+ you can choose a different MyDumper tag, the command below creates a `.ddev/.env.mydumper` file that you can commit:
+
+```sh
+ddev dotenv set .ddev/.env.mydumper --mydumper-tag v0.17.2-19
+ddev add-on get stasadev/ddev-mydumper
 ddev restart
 ```
 

--- a/docker-compose.mydumper.yaml
+++ b/docker-compose.mydumper.yaml
@@ -2,7 +2,7 @@
 services:
   mydumper:
     container_name: ddev-${DDEV_SITENAME}-mydumper
-    image: mydumper/mydumper:v0.16.6-2
+    image: mydumper/mydumper:${MYDUMPER_TAG:-latest}
     user: '$DDEV_UID:$DDEV_GID'
     command: tail -f /dev/null
     working_dir: /var/www/html

--- a/mydumper/mydumper.cnf
+++ b/mydumper/mydumper.cnf
@@ -33,6 +33,8 @@
 SQL_MODE='NO_AUTO_VALUE_ON_ZERO' /*!40101
 UNIQUE_CHECKS=0 /*!40114
 FOREIGN_KEY_CHECKS=0 /*!40114
+# SQL_LOG_BIN will be added by default in next release and -e will be deprecated
+# SQL_LOG_BIN=0
 
 # sync_binlog = 0
 # innodb_flush_log_at_trx_commit = 0

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -4,7 +4,7 @@ setup() {
   export TESTDIR=~/tmp/test-mydumper
   mkdir -p $TESTDIR
   export PROJNAME=test-mydumper
-  export DDEV_NON_INTERACTIVE=true
+  export DDEV_NONINTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
@@ -26,18 +26,30 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
 
-@test "install from release" {
+@test "install from directory with MyDumper tag v0.17.2-19" {
   set -eu -o pipefail
-  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get stasadev/ddev-mydumper with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get stasadev/ddev-mydumper
-  ddev restart >/dev/null
+  cd ${TESTDIR}
+  echo "# ddev dotenv set .ddev/.env.mydumper --mydumper-tag v0.17.2-19"
+  ddev dotenv set .ddev/.env.mydumper --mydumper-tag v0.17.2-19
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
+  ddev restart
+  ddev mydumper -V | grep "^mydumper v0.17.2-19"
   health_checks
 }
 
+# bats test_tags=release
+@test "install from release" {
+  set -eu -o pipefail
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  echo "# ddev add-on get stasadev/ddev-mydumper with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get stasadev/ddev-mydumper
+  ddev restart >/dev/null
+  health_checks
+}


### PR DESCRIPTION
## The Issue

There is a fixed MyDumper tag.

## How This PR Solves The Issue

- Adds ability to change the tag with `.ddev/.env.mydumper`.
- Chores.

## Manual Testing Instructions

```
ddev dotenv set .ddev/.env.mydumper --mydumper-tag v0.17.2-19
ddev add-on get https://github.com/stasadev/ddev-mydumper/tarball/20250208_stasadev_mydumper_tag
ddev restart
ddev mydumper -V
mydumper v0.17.2-19, built against MySQL 8.0.40-31 with SSL support
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
