### PR TITLE
refactor: use `ddev debug configyaml` as more reliable command to check for `db`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ After installation, make sure to commit the `.ddev` directory to version control
 
 | Command | Description |
 | ------- | ----------- |
-| `ddev mydumper` | Backup export. |
-| `ddev myloader` | Backup import. |
+| `ddev mydumper` | Backup export |
+| `ddev myloader` | Backup import |
 
 Examples:
 
@@ -60,4 +60,4 @@ All customization options (use with caution):
 
 ## Credits
 
-Contributed and maintained by [@stasadev](https://github.com/stasadev).
+**Contributed and maintained by [@stasadev](https://github.com/stasadev)**

--- a/install.yaml
+++ b/install.yaml
@@ -12,8 +12,8 @@ pre_install_actions:
   - |
     #ddev-nodisplay
     #ddev-description:Check for db service
-    if ({{ contains "db" (list .DdevProjectConfig.omit_containers | toString) }}); then
-      echo "Unable to install the application because no db service was found"
+    if ddev debug configyaml 2>/dev/null | grep omit_containers | grep -q db; then
+      echo "Unable to install the add-on because no db service was found"
       exit 2
     fi
   - |


### PR DESCRIPTION
## The Issue

The original code doesn't check for overrides, i.e. if you have https://github.com/ddev/ddev-sqlsrv installed, then this add-on won't see that there is no `db`.

## How This PR Solves The Issue

Uses `ddev debug configyaml`, that checks for overrides.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/stasadev/ddev-mydumper/tarball/20250327_stasadev_config_db
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
