### PR TITLE
refactor: use `#!/usr/bin/env bash` instead of `#!/bin/bash`

### DIFF
--- a/commands/mydumper/mydumper
+++ b/commands/mydumper/mydumper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Export a consistent backup

--- a/commands/mydumper/myloader
+++ b/commands/mydumper/myloader
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated
 ## Description: Read the backup from `ddev mydumper`, connect the to destination database and import the backup


### PR DESCRIPTION
## The Issue

Use `#!/usr/bin/env bash` (it doesn't really matter here, but it should be promoted).

## How This PR Solves The Issue

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/stasadev/ddev-mydumper/tarball/20250428_stasadev_bash
ddev restart
ddev mydumper
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
